### PR TITLE
hide sensitive information in log output

### DIFF
--- a/Python/Flask_Book_Library/project/customers/models.py
+++ b/Python/Flask_Book_Library/project/customers/models.py
@@ -22,7 +22,8 @@ class Customer(db.Model):
         print("Getting: " + str(self),flush=True)
 
     def __repr__(self):
-        return f"Customer(ID: {self.id}, Name: {self.name}, City: {self.city}, Age: {self.age}, Pesel: {self.pesel}, Street: {self.street}, AppNo: {self.appNo})"
+
+        return f"Customer(ID: {self.id}, Name: {'*' * len(self.name)} , City: {'*' * len(self.city)}, Age: {'*' * len(self.age)}, Pesel: {'*' * len(self.pesel)}, Street: {'*' * len(self.street)}, AppNo:{'*' * len(self.appNo)})"
 
 
 with app.app_context():


### PR DESCRIPTION
**Zadanie 1**
Zaimplementowano właściwe wyświetlanie logów zastępując każdy znak stringów zawierających dane poufnę na znak: "*"

**Zadanie 2**
![Screenshot from 2023-11-22 19-39-09](https://github.com/Adrjnk/task2/assets/61837593/fad81c95-8072-4403-8551-80724cbf08af)

Wynika, że jedna biblioteka o nazwie "healpy" jest podatna. Podatność została dokładnie opisana w następującym CVE https://data.safetycli.com/vulnerabilities/CVE-2023-38545/61774/. Sugerowane jest zaktualizowanie do wersji 1.16.6.

**Zadanie 3**
![Screenshot from 2023-11-22 19-41-21](https://github.com/Adrjnk/task2/assets/61837593/1c99be54-34f3-45bb-a096-5a79a1d0b762)

Wynika, że w trakcie dwóch commitów zostały dodane dane wrażliwe takie jak klucze prywatne. Aby uniknąć tego typu sytuacji
należy dodać plik .gitignore do repozystorium  na etapie jego tworzenia oraz umieść w nim wpisy dla plików zawierających klucze prywatne. Dobrą praktyką jest nie umieszczać kluczy bezpośrednio w kodzie; sugerowane jest używać plików konfiguracyjnych. Istnieją narzędzia takie jak HashiCorp Vault czy AWS Secrets Manager do zarządzania sekretami.